### PR TITLE
[286 296 297 306 307 347 350 352] update eco news controller response codes

### DIFF
--- a/core/src/main/java/greencity/constant/HttpStatuses.java
+++ b/core/src/main/java/greencity/constant/HttpStatuses.java
@@ -10,6 +10,7 @@ public final class HttpStatuses {
     public static final String NOT_FOUND = "Not Found";
     public static final String SEE_OTHER = "See Other";
     public static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
+    public static final String UNSUPPORTED_MEDIA_TYPE = "Unsupported Media Type";
 
     HttpStatuses() {
     }

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -114,7 +114,7 @@ public class EcoNewsController {
             @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
             @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
             @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
-            @ApiResponse(responseCode = "415", description = HttpStatuses.SEE_OTHER)
+            @ApiResponse(responseCode = "415", description = HttpStatuses.UNSUPPORTED_MEDIA_TYPE)
     })
     @PostMapping(path = "/uploadImages", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<String[]> uploadImages(

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -244,7 +244,9 @@ public class EcoNewsController {
     @Operation(summary = "Delete eco news.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
             @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
             @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping("/{econewsId}")

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -26,7 +27,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import jakarta.validation.Valid;
+
 import java.security.Principal;
 import java.util.List;
 import java.util.Locale;
@@ -48,7 +49,7 @@ public class EcoNewsController {
      */
     @Operation(summary = "Get three last eco news.")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @GetMapping("/newest")
     public ResponseEntity<List<EcoNewsDto>> getThreeLastEcoNews() {
@@ -87,10 +88,11 @@ public class EcoNewsController {
     @Operation(summary = "Upload image for eco news.")
     @ResponseStatus(value = HttpStatus.CREATED)
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED,
+            @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED,
                     content = @Content(schema = @Schema(implementation = String.class))),
-        @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
-        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
+            @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
     })
     @PostMapping(path = "/uploadImage", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<String> uploadImage(
@@ -108,9 +110,9 @@ public class EcoNewsController {
     @Operation(summary = "Upload array of images for eco news.")
     @ResponseStatus(value = HttpStatus.CREATED)
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED),
-        @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
-        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
+            @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED),
+            @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
     })
     @PostMapping(path = "/uploadImages", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<String[]> uploadImages(
@@ -124,10 +126,10 @@ public class EcoNewsController {
      */
     @Operation(summary = "Delete image")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(responseCode = "403", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping("/deleteImage")
     public void deleteImage(@RequestParam String imagePath) {
@@ -142,13 +144,13 @@ public class EcoNewsController {
      */
     @Operation(summary = "Update eco news")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
                     content = @Content(schema = @Schema(implementation = EcoNewsGenericDto.class))),
-        @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
-        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
+            @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
     })
     @PutMapping(path = "/update", consumes = {MediaType.APPLICATION_JSON_VALUE,
-        MediaType.MULTIPART_FORM_DATA_VALUE})
+            MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<EcoNewsGenericDto> update(
             @Parameter(description = SwaggerExampleModel.UPDATE_ECO_NEWS,
                     required = true) @Valid @RequestPart UpdateEcoNewsDto updateEcoNewsDto,
@@ -167,9 +169,9 @@ public class EcoNewsController {
      */
     @Operation(summary = "Get eco news by id.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @ApiLocale
     @GetMapping("/{id}")
@@ -187,8 +189,8 @@ public class EcoNewsController {
      */
     @Operation(summary = "Get eco news by authorised user.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
     })
     @GetMapping("/byUser")
     public ResponseEntity<List<EcoNewsDto>> getEcoNewsByUser(@Parameter(hidden = true) @CurrentUser UserVO user) {
@@ -204,8 +206,8 @@ public class EcoNewsController {
      */
     @Operation(summary = "Find all eco news by page.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
     })
     @GetMapping("")
     @ApiPageable
@@ -221,8 +223,8 @@ public class EcoNewsController {
      */
     @Operation(summary = "Find all eco news by page.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
     })
     @GetMapping("/byUserPage")
     @ApiPageable
@@ -241,9 +243,9 @@ public class EcoNewsController {
      */
     @Operation(summary = "Delete eco news.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping("/{econewsId}")
     public ResponseEntity<Object> delete(@PathVariable Long econewsId,
@@ -260,8 +262,8 @@ public class EcoNewsController {
      */
     @Operation(summary = "Get eco news by tags")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
     })
     @GetMapping("/tags")
     @ApiPageable
@@ -284,7 +286,7 @@ public class EcoNewsController {
      */
     @Operation(summary = "Get three recommended eco news.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK)
     })
     @GetMapping("/recommended")
     public ResponseEntity<List<EcoNewsDto>> getThreeRecommendedEcoNews(@RequestParam() Long openedEcoNewsId) {
@@ -322,10 +324,10 @@ public class EcoNewsController {
      */
     @Operation(summary = "Like eco news")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @PostMapping("/like")
     public void like(@RequestParam("id") Long id, @Parameter(hidden = true) @CurrentUser UserVO user) {
@@ -337,9 +339,9 @@ public class EcoNewsController {
      */
     @Operation(summary = "Dislike eco news")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
     })
     @PostMapping("/dislike")
     public void dislike(@RequestParam("id") Long id, @Parameter(hidden = true) @CurrentUser UserVO user) {
@@ -353,9 +355,9 @@ public class EcoNewsController {
      */
     @Operation(summary = "Count likes by id")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @GetMapping("/countLikes/{econewsId}")
     public ResponseEntity<Integer> countLikesForEcoNews(@PathVariable Long econewsId) {
@@ -381,10 +383,10 @@ public class EcoNewsController {
      */
     @Operation(summary = "Get content and source in eco news by id")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.FORBIDDEN),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
                     content = @Content(schema = @Schema(implementation = NotFoundException.class)))
     })
     @GetMapping("/contentAndSourceForEcoNews/{id}")

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -112,6 +112,7 @@ public class EcoNewsController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED),
             @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
             @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
     })
     @PostMapping(path = "/uploadImages", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
@@ -127,8 +128,9 @@ public class EcoNewsController {
     @Operation(summary = "Delete image")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
             @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-            @ApiResponse(responseCode = "403", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
             @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping("/deleteImage")

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -113,7 +113,8 @@ public class EcoNewsController {
             @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED),
             @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
             @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "415", description = HttpStatuses.SEE_OTHER)
     })
     @PostMapping(path = "/uploadImages", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<String[]> uploadImages(

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -15,7 +15,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -580,6 +579,8 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
     }
 
+
+
     /**
      * Customize the response for WrongIdException.
      *
@@ -608,5 +609,14 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     private Map<String, Object> getErrorAttributes(WebRequest webRequest) {
         return new HashMap<>(errorAttributes.getErrorAttributes(webRequest,
                 ErrorAttributeOptions.of(ErrorAttributeOptions.Include.MESSAGE)));
+    }
+
+    @ExceptionHandler(UnsupportedMediaTypeException.class)
+    public final ResponseEntity<Object> handleUnsupportedMediaTypeException(
+            UnsupportedMediaTypeException ex, WebRequest request) {
+        log.info(ex.getMessage());
+        ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
+        exceptionResponse.setMessage(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(exceptionResponse);
     }
 }

--- a/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.converters.UserArgumentResolver;
 import greencity.dto.econews.AddEcoNewsDtoRequest;
 import greencity.dto.user.UserVO;
-import greencity.exception.exceptions.NotFoundException;
+import greencity.exception.exceptions.*;
 import greencity.exception.handler.CustomExceptionHandler;
 import greencity.service.EcoNewsService;
 import greencity.service.TagsService;
@@ -30,6 +30,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
 import java.util.Collections;
@@ -37,6 +38,8 @@ import java.util.List;
 
 import static greencity.ModelUtils.getPrincipal;
 import static greencity.ModelUtils.getUserVO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -67,17 +70,17 @@ class EcoNewsControllerTest {
     @BeforeEach
     public void setUp() {
         this.mockMvc = MockMvcBuilders
-            .standaloneSetup(ecoNewsController)
-            .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
-                new UserArgumentResolver(userService, modelMapper))
-            .setControllerAdvice(new CustomExceptionHandler(errorAttributes, objectMapper))
-            .build();
+                .standaloneSetup(ecoNewsController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
+                        new UserArgumentResolver(userService, modelMapper))
+                .setControllerAdvice(new CustomExceptionHandler(errorAttributes, objectMapper))
+                .build();
     }
 
     @Test
     void getThreeLastEcoNewsTest() throws Exception {
         mockMvc.perform(get(ecoNewsLink + "/newest"))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).getThreeLastEcoNews();
     }
@@ -85,10 +88,143 @@ class EcoNewsControllerTest {
     @Test
     void uploadImageTest() throws Exception {
         MockMultipartFile image = new MockMultipartFile("data", "filename.txt",
-            "text/plain", "some xml".getBytes());
+                "text/plain", "some xml".getBytes());
         mockMvc.perform(MockMvcRequestBuilders.multipart(ecoNewsLink + uploadImageLink)
-            .file(image)).andExpect(status().isCreated());
+                .file(image)).andExpect(status().isCreated());
         verify(ecoNewsService).uploadImage(isNull());
+    }
+
+    @Test
+    void uploadImageTest_CreatedStatus() throws Exception {
+        MockMultipartFile image = new MockMultipartFile("image", "image.png",
+                "image/png", "some-image-content".getBytes());
+
+        when(ecoNewsService.uploadImage(any(MultipartFile.class))).thenReturn("image-path");
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(ecoNewsLink + "/uploadImage")
+                        .file(image))
+                .andExpect(status().isCreated());
+
+        verify(ecoNewsService).uploadImage(any(MultipartFile.class));
+    }
+
+    @Test
+    void uploadImageTest_BadRequest() throws Exception {
+        MockMultipartFile image = new MockMultipartFile("image", "", "text/plain", "".getBytes());
+
+        doThrow(new BadRequestException("Invalid file"))
+                .when(ecoNewsService).uploadImage(any(MultipartFile.class));
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(ecoNewsLink + "/uploadImage")
+                        .file(image))
+                .andExpect(status().isBadRequest())
+                .andExpect(result ->
+                        assertTrue(result.getResolvedException() instanceof BadRequestException))
+                .andExpect(result ->
+                        assertEquals("Invalid file", result.getResolvedException().getMessage()));
+
+        verify(ecoNewsService, times(1)).uploadImage(any(MultipartFile.class));
+    }
+
+    @Test
+    void uploadImageTest_Forbidden() throws Exception {
+        MockMultipartFile image = new MockMultipartFile("image", "image.png", "image/png", "image-content".getBytes());
+
+        doThrow(new UserHasNoPermissionToAccessException("Access denied"))
+                .when(ecoNewsService).uploadImage(any(MultipartFile.class));
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(ecoNewsLink + "/uploadImage")
+                        .file(image))
+                .andExpect(status().isForbidden())
+                .andExpect(result ->
+                        assertTrue(result.getResolvedException() instanceof UserHasNoPermissionToAccessException))
+                .andExpect(result ->
+                        assertEquals("Access denied", result.getResolvedException().getMessage()));
+
+        verify(ecoNewsService, times(1)).uploadImage(any(MultipartFile.class));
+    }
+
+    @Test
+    void uploadImagesTest_CreatedStatus() throws Exception {
+        MockMultipartFile image1 = new MockMultipartFile("images", "image1.png",
+                "image/png", "image1-content".getBytes());
+        MockMultipartFile image2 = new MockMultipartFile("images", "image2.png",
+                "image/png", "image2-content".getBytes());
+
+        when(ecoNewsService.uploadImages(any(MultipartFile[].class))).thenReturn(new String[]{"path1", "path2"});
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(ecoNewsLink + "/uploadImages")
+                        .file(image1)
+                        .file(image2))
+                .andExpect(status().isCreated());
+
+        verify(ecoNewsService).uploadImages(any(MultipartFile[].class));
+    }
+
+    @Test
+    void uploadImagesTest_BadRequest() throws Exception {
+        MockMultipartFile image = new MockMultipartFile("images", "", "", "".getBytes());
+
+        doThrow(new BadRequestException("Invalid files"))
+                .when(ecoNewsService).uploadImages(any(MultipartFile[].class));
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(ecoNewsLink + "/uploadImages")
+                        .file(image))
+                .andExpect(status().isBadRequest())
+                .andExpect(result ->
+                        assertTrue(result.getResolvedException() instanceof BadRequestException))
+                .andExpect(result ->
+                        assertEquals("Invalid files", result.getResolvedException().getMessage()));
+
+        verify(ecoNewsService, times(1)).uploadImages(any(MultipartFile[].class));
+    }
+
+    @Test
+    void uploadImagesTest_UnsupportedMediaType() throws Exception {
+        MockMultipartFile image1 = new MockMultipartFile("images", "image1.txt", "text/plain", "some text content".getBytes());
+        MockMultipartFile image2 = new MockMultipartFile("images", "image2.doc", "application/msword", "some document content".getBytes());
+
+        doThrow(new UnsupportedMediaTypeException("Only PNG and JPEG images are supported"))
+                .when(ecoNewsService).uploadImages(any(MultipartFile[].class));
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(ecoNewsLink + "/uploadImages")
+                        .file(image1)
+                        .file(image2))
+                .andExpect(status().isUnsupportedMediaType())
+                .andExpect(result ->
+                        assertTrue(result.getResolvedException() instanceof UnsupportedMediaTypeException))
+                .andExpect(result ->
+                        assertEquals("Only PNG and JPEG images are supported", result.getResolvedException().getMessage()));
+
+        verify(ecoNewsService, times(1)).uploadImages(any(MultipartFile[].class));
+    }
+
+    @Test
+    void uploadImagesTest_Unauthorized() throws Exception {
+        MockMultipartFile image = new MockMultipartFile("images", "image.png", "image/png", "image-content".getBytes());
+
+        doThrow(new AuthenticationException("Unauthorized"))
+                .when(ecoNewsService).uploadImages(any(MultipartFile[].class));
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(ecoNewsLink + "/uploadImages")
+                        .file(image))
+                .andExpect(status().isUnauthorized());
+
+        verify(ecoNewsService, times(1)).uploadImages(any(MultipartFile[].class));
+    }
+
+    @Test
+    void uploadImagesTest_Forbidden() throws Exception {
+        MockMultipartFile image = new MockMultipartFile("images", "image.png", "image/png", "image-content".getBytes());
+
+        doThrow(new UserHasNoPermissionToAccessException("Access denied"))
+                .when(ecoNewsService).uploadImages(any(MultipartFile[].class));
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(ecoNewsLink + "/uploadImages")
+                        .file(image))
+                .andExpect(status().isForbidden());
+
+        verify(ecoNewsService, times(1)).uploadImages(any(MultipartFile[].class));
     }
 
     @Test
@@ -96,42 +232,42 @@ class EcoNewsControllerTest {
         Principal principal = Mockito.mock(Principal.class);
         when(principal.getName()).thenReturn("Olivia.Johnson@gmail.com");
         String json = "{\n" +
-            "\"title\": \"title\",\n" +
-            " \"tags\": [\"news\"],\n" +
-            " \"text\": \"content content content\", \n" +
-            "\"source\": \"\",\n" +
-            " \"image\": null\n" +
-            "}";
+                      "\"title\": \"title\",\n" +
+                      " \"tags\": [\"news\"],\n" +
+                      " \"text\": \"content content content\", \n" +
+                      "\"source\": \"\",\n" +
+                      " \"image\": null\n" +
+                      "}";
         MockMultipartFile jsonFile =
-            new MockMultipartFile("addEcoNewsDtoRequest", "", "application/json", json.getBytes());
+                new MockMultipartFile("addEcoNewsDtoRequest", "", "application/json", json.getBytes());
 
         this.mockMvc.perform(multipart(ecoNewsLink)
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
 
         ObjectMapper mapper = new ObjectMapper();
         AddEcoNewsDtoRequest addEcoNewsDtoRequest = mapper.readValue(json, AddEcoNewsDtoRequest.class);
 
         verify(ecoNewsService)
-            .saveEcoNews(eq(addEcoNewsDtoRequest), isNull(), eq("Olivia.Johnson@gmail.com"));
+                .saveEcoNews(eq(addEcoNewsDtoRequest), isNull(), eq("Olivia.Johnson@gmail.com"));
     }
 
     @Test
     void saveBadRequestTest() throws Exception {
         mockMvc.perform(post(ecoNewsLink)
-            .content("{}")
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        .content("{}")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     void getEcoNewsById() throws Exception {
         mockMvc.perform(get(ecoNewsLink + "/{id}", 1))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).findDtoByIdAndLanguage(1L, "en");
     }
@@ -142,8 +278,8 @@ class EcoNewsControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
 
         mockMvc.perform(get(ecoNewsLink + "/byUser")
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).getAllPublishedNewsByUser(userVO);
     }
@@ -155,7 +291,7 @@ class EcoNewsControllerTest {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
 
         mockMvc.perform(get(ecoNewsLink + "?page=1"))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).findGenericAll(pageable);
     }
@@ -168,7 +304,7 @@ class EcoNewsControllerTest {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
 
         mockMvc.perform(get(ecoNewsLink + "/byUserPage?page=1&size=2"))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).findAllByUser(null, pageable);
     }
@@ -179,8 +315,8 @@ class EcoNewsControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
 
         mockMvc.perform(delete(ecoNewsLink + "/{econewsId}", 1)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).delete(1L, userVO);
     }
@@ -193,7 +329,7 @@ class EcoNewsControllerTest {
         List<String> tags = Collections.singletonList("eco");
 
         mockMvc.perform(get("/econews/tags?page=5&tags=eco"))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).find(pageable, tags);
     }
@@ -205,7 +341,7 @@ class EcoNewsControllerTest {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
 
         mockMvc.perform(get("/econews/tags?page=5"))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).findGenericAll(pageable);
     }
@@ -213,7 +349,7 @@ class EcoNewsControllerTest {
     @Test
     void getThreeRecommendedEcoNewsTest() throws Exception {
         mockMvc.perform(get(ecoNewsLink + "/recommended?openedEcoNewsId=" + 1L))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).getThreeRecommendedEcoNews(1L);
     }
@@ -222,7 +358,7 @@ class EcoNewsControllerTest {
     void findAllEcoNewsTagsTest() throws Exception {
         String language = "en";
         mockMvc.perform(get(ecoNewsLink + "/tags/all?lang=" + language))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(tagsService).findAllEcoNewsTags(language);
     }
@@ -233,8 +369,8 @@ class EcoNewsControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
 
         mockMvc.perform(post(ecoNewsLink + "/like?id=1")
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).like(userVO, 1L);
     }
@@ -246,8 +382,8 @@ class EcoNewsControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
         // when
         mockMvc.perform(post(ecoNewsLink + "/dislike?id=1")
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         // then
         verify(ecoNewsService).dislike(userVO, 1L);
 
@@ -256,7 +392,7 @@ class EcoNewsControllerTest {
     @Test
     void countLikesForEcoNewsTest() throws Exception {
         mockMvc.perform(get(ecoNewsLink + "/countLikes/{econewsId}", 1L))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).countLikesForEcoNews(1L);
     }
@@ -267,8 +403,8 @@ class EcoNewsControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
 
         mockMvc.perform(get(ecoNewsLink + "/isLikedByUser?econewsId=1")
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).checkNewsIsLikedByUser(1L, userVO);
     }
@@ -276,8 +412,8 @@ class EcoNewsControllerTest {
     @Test
     void findAmountOfPublishedNews() throws Exception {
         mockMvc.perform(get(ecoNewsLink + "/count")
-            .param("userId", "1"))
-            .andExpect(status().isOk());
+                        .param("userId", "1"))
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).getAmountOfPublishedNewsByUserId(1L);
     }
@@ -285,7 +421,7 @@ class EcoNewsControllerTest {
     @Test
     void getContentAndSourceForEcoNewsById() throws Exception {
         mockMvc.perform(get(ecoNewsLink + "/contentAndSourceForEcoNews/{id}", 1L))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(ecoNewsService).getContentAndSourceForEcoNewsById(1L);
 
@@ -297,7 +433,7 @@ class EcoNewsControllerTest {
         Mockito.when(ecoNewsService.getContentAndSourceForEcoNewsById(1L)).thenThrow(NotFoundException.class);
 
         mockMvc.perform(get(ecoNewsLink + "/contentAndSourceForEcoNews/{id}", 1L))
-            .andExpect(status().isNotFound());
+                .andExpect(status().isNotFound());
 
         verify(ecoNewsService).getContentAndSourceForEcoNewsById(1L);
     }

--- a/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
@@ -322,6 +322,54 @@ class EcoNewsControllerTest {
     }
 
     @Test
+    void deleteTest_BadRequest() throws Exception {
+        Long invalidEcoNewsId = -1L;
+        UserVO userVO = getUserVO();
+
+        when(userService.findByEmail(eq(principal.getName()))).thenReturn(userVO);
+
+        doThrow(new BadRequestException("Invalid EcoNews ID"))
+                .when(ecoNewsService).delete(eq(invalidEcoNewsId), eq(userVO));
+
+        mockMvc.perform(delete("/econews/{econewsId}", invalidEcoNewsId)
+                        .principal(principal)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(result ->
+                        assertTrue(result.getResolvedException() instanceof BadRequestException))
+                .andExpect(result ->
+                        assertEquals("Invalid EcoNews ID", result.getResolvedException().getMessage()));
+
+        verify(ecoNewsService, times(1)).delete(eq(invalidEcoNewsId), eq(userVO));
+    }
+
+
+    @Test
+    void deleteTest_Forbidden() throws Exception {
+        Long ecoNewsId = 1L;
+        UserVO userVO = getUserVO();
+
+        when(userService.findByEmail(eq(principal.getName()))).thenReturn(userVO);
+
+        doThrow(new UserHasNoPermissionToAccessException("Access denied"))
+                .when(ecoNewsService).delete(eq(ecoNewsId), eq(userVO));
+
+        mockMvc.perform(delete("/econews/{econewsId}", ecoNewsId)
+                        .principal(principal)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(result ->
+                        assertTrue(result.getResolvedException() instanceof UserHasNoPermissionToAccessException))
+                .andExpect(result ->
+                        assertEquals("Access denied", result.getResolvedException().getMessage()));
+
+        verify(ecoNewsService, times(1)).delete(eq(ecoNewsId), eq(userVO));
+    }
+
+
+
+
+    @Test
     void getEcoNewsTest() throws Exception {
         int pageNumber = 5;
         int pageSize = 20;

--- a/service-api/src/main/java/greencity/exception/exceptions/AuthenticationException.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/AuthenticationException.java
@@ -1,0 +1,29 @@
+package greencity.exception.exceptions;
+
+/**
+ * Exception that represents an authentication failure.
+ * This exception is thrown when the authentication process fails due to invalid credentials or other reasons.
+ *
+ * @author Viktoriia Rychenko
+ * @version 1.0
+ */
+public class AuthenticationException extends RuntimeException {
+    /**
+     * Constructor for AuthenticationException with a custom message.
+     *
+     * @param message the message describing the reason for the authentication failure.
+     */
+    public AuthenticationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor for AuthenticationException with a custom message and a cause.
+     *
+     * @param message the message describing the reason for the authentication failure.
+     * @param cause   the root cause of the exception.
+     */
+    public AuthenticationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/service-api/src/main/java/greencity/exception/exceptions/UnsupportedMediaTypeException.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/UnsupportedMediaTypeException.java
@@ -1,0 +1,16 @@
+package greencity.exception.exceptions;
+
+/**
+ * Exception thrown when an unsupported media type is provided.
+ * @author Viktoriia Rychenko
+ */
+public class UnsupportedMediaTypeException extends RuntimeException {
+    /**
+     * Constructor for UnsupportedMediaTypeException.
+     *
+     * @param message - providing message.
+     */
+    public UnsupportedMediaTypeException(String message) {
+        super(message);
+    }
+}

--- a/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
@@ -18,10 +18,7 @@ import greencity.entity.*;
 import greencity.entity.localization.TagTranslation;
 import greencity.enums.Role;
 import greencity.enums.TagType;
-import greencity.exception.exceptions.BadRequestException;
-import greencity.exception.exceptions.NotFoundException;
-import greencity.exception.exceptions.NotSavedException;
-import greencity.exception.exceptions.UnsupportedSortException;
+import greencity.exception.exceptions.*;
 import greencity.filters.EcoNewsSpecification;
 import greencity.filters.SearchCriteria;
 import greencity.repository.EcoNewsRepo;
@@ -317,7 +314,7 @@ public class EcoNewsServiceImpl implements EcoNewsService {
     public void delete(Long id, UserVO user) {
         EcoNewsVO ecoNewsVO = findById(id);
         if (user.getRole() != Role.ROLE_ADMIN && !user.getId().equals(ecoNewsVO.getAuthor().getId())) {
-            throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
+            throw new UserHasNoPermissionToAccessException(ErrorMessage.USER_HAS_NO_PERMISSION);
         }
         String accessToken = httpServletRequest.getHeader(AUTHORIZATION);
         CompletableFuture.runAsync(

--- a/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
@@ -16,10 +16,7 @@ import greencity.entity.EcoNews;
 import greencity.entity.Tag;
 import greencity.entity.User;
 import greencity.enums.TagType;
-import greencity.exception.exceptions.BadRequestException;
-import greencity.exception.exceptions.NotFoundException;
-import greencity.exception.exceptions.NotSavedException;
-import greencity.exception.exceptions.UnsupportedSortException;
+import greencity.exception.exceptions.*;
 import greencity.filters.EcoNewsSpecification;
 import greencity.filters.SearchCriteria;
 import greencity.repository.EcoNewsRepo;
@@ -364,7 +361,7 @@ class EcoNewsServiceImplTest {
         when(ecoNewsRepo.findById(1L)).thenReturn(Optional.of(ecoNews));
         when(modelMapper.map(ecoNews, EcoNewsVO.class)).thenReturn(ecoNewsVO);
         ecoNewsVO.setAuthor(author);
-        assertThrows(BadRequestException.class, () -> ecoNewsService.delete(1L, userVO));
+        assertThrows(UserHasNoPermissionToAccessException.class, () -> ecoNewsService.delete(1L, userVO));
     }
 
     @Test


### PR DESCRIPTION
Fix tickets 306 307 347 350 352 - response codes 403, 400 added to deleteImage method, 400 added to uploadImage method, 401 and 415 added to uploadImages method of EcoNewsController documentation.
AuthenticationException.java and UnsupportedMediaTypeException.java were added, also CustomExceptionHandler and HttpStatuses classes were modified accordingly to process these exceptions.

Also tests were added to test new fixes to EcoNewsControllerTest.java

Fix issues  286, 296 and 297 - adding 400 and 403 status codes to delete method of EcoNewsController, also I modified BadRequestException to UserHasNoPermissionToAccessException i
n delete method of EcoNewsServiceImpl.java.
Also Unit tests for 400 and 403 statuses checks added to EcoNewsControllerTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a new constant for Unsupported Media Type HTTP status.
  - Introduced new exception classes for authentication and media type handling.
  - Enhanced API documentation with additional response codes for EcoNews operations.

- **Bug Fixes**
  - Improved error handling for EcoNews operations, including specific exceptions for permission issues.

- **Documentation**
  - Updated API response codes and descriptions in EcoNews controller.

- **Refactor**
  - Streamlined exception imports and improved error message handling for various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->